### PR TITLE
Fix: Update token path, suppress warnings

### DIFF
--- a/config/build.ts
+++ b/config/build.ts
@@ -26,11 +26,13 @@ export function getStyleDictionaryConfig(
   platform: PlatformTypes
 ): StyleDictionaryPackage.Config {
   return {
-    source: [
+    include: [
       'tokens/**/**/*.json',
       'tokens/alias/**/*.json',
       'tokens/components/**/*.json',
-      `tokens/globals/${brand.name}/*.json`
+    ],
+    source: [
+      `tokens/global/${brand.name}/*.json`
     ],
     platforms: {
       'web/js': {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/design-language-system",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": false,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Major Changes 🔄
- Using the include array so that token overrides don't show warnings
- Fixed wrong path for brand tokens