### PR TITLE
update: fixes for elevations, new border radius and background overlay tokens

### DIFF
--- a/tokens/alias/dark.json
+++ b/tokens/alias/dark.json
@@ -163,6 +163,19 @@
         "value": "{global.color.neutrals.white}",
         "type": "color",
         "description": "Tooltip background"
+      },
+      "overlay": {
+        "value": "{global.color.neutrals.black}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "value": "0.84",
+              "space": "lch"
+            }
+          }
+        }
       }
     },
     "interaction": {
@@ -449,9 +462,21 @@
           "blur": "6",
           "spread": "0",
           "color": "rgba(0,0,0,0.18)",
-          "type": "innerShadow"
+          "type": "dropShadow"
         },
         "type": "boxShadow"
+      },
+      "s-inverted": {
+        "value": {
+          "x": "0",
+          "y": "-2",
+          "blur": "6",
+          "spread": "0",
+          "color": "rgba(0,0,0,0.18)",
+          "type": "dropShadow"
+        },
+        "type": "boxShadow",
+        "description": "Inverted shadow for elements that appear above the component"
       },
       "l": {
         "value": [
@@ -460,14 +485,16 @@
             "y": "16",
             "blur": "32",
             "spread": "0",
-            "color": "rgba(0,0,0,0.18)"
+            "color": "rgba(0,0,0,0.18)",
+            "type": "dropShadow"
           },
           {
             "x": "0",
             "y": "4",
             "blur": "8",
             "spread": "0",
-            "color": "rgba(0,0,0,0.08)"
+            "color": "rgba(0,0,0,0.08)",
+            "type": "dropShadow"
           }
         ],
         "type": "boxShadow"

--- a/tokens/alias/light.json
+++ b/tokens/alias/light.json
@@ -215,6 +215,20 @@
       "neutralsubtle": {
         "value": "{global.color.neutrals.20}",
         "type": "color"
+      },
+      "overlay": {
+        "value": "{global.color.neutrals.black}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "value": "0.24",
+              "space": "lch"
+            }
+          }
+        },
+        "description": "Page dimming when the modal component is active"
       }
     },
     "action": {
@@ -352,9 +366,22 @@
           "blur": "6",
           "spread": "0",
           "color": "rgba(58,59,63,0.18)",
-          "type": "innerShadow"
+          "type": "dropShadow"
         },
-        "type": "boxShadow"
+        "type": "boxShadow",
+        "description": "Default shadow for components, like notification banners, dropdowns, popups;"
+      },
+      "s-inverted": {
+        "value": {
+          "x": "0",
+          "y": "-2",
+          "blur": "6",
+          "spread": "0",
+          "color": "rgba(58,59,63,0.18)",
+          "type": "dropShadow"
+        },
+        "type": "boxShadow",
+        "description": "Inverted shadow for elements that appear above the component"
       },
       "l": {
         "value": [
@@ -363,17 +390,20 @@
             "y": "16",
             "blur": "32",
             "spread": "0",
-            "color": "rgba(58,59,63,0.18)"
+            "color": "rgba(58,59,63,0.18)",
+            "type": "dropShadow"
           },
           {
             "x": "0",
             "y": "4",
             "blur": "8",
             "spread": "0",
-            "color": "rgba(58,59,63,0.08)"
+            "color": "rgba(58,59,63,0.08)",
+            "type": "dropShadow"
           }
         ],
-        "type": "boxShadow"
+        "type": "boxShadow",
+        "description": "Shadow for modals"
       }
     },
     "typography": {

--- a/tokens/global/global.json
+++ b/tokens/global/global.json
@@ -952,6 +952,12 @@
           "type": "textCase"
         }
       }
+    },
+    "borderRadius": {
+      "none": {
+        "value": "0",
+        "type": "borderRadius"
+      }
     }
   }
 }


### PR DESCRIPTION
## Major Changes 🔄
- Fixes for elevations: wrong inner-shadow value was changed to a drop-shadow;
- Added “s-inverted” elevation token for containers that appear above the component;
- “Background-overlay” alias token for page dimming (when modal is active);
- New global token “global.borderRadius.none”;