### PR TITLE
fix: Move `dependencies` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,13 +45,6 @@
     "url": "https://github.com/linode/design-language-system/issues"
   },
   "homepage": "https://github.com/linode/design-language-system#readme",
-  "dependencies": {
-    "@tokens-studio/sd-transforms": "1.2.0",
-    "react": "^17.0.2",
-    "react-copy-to-clipboard": "^5.1.0",
-    "react-dom": "^17.0.2",
-    "style-dictionary": "4.0.1"
-  },
   "devDependencies": {
     "@storybook/addon-essentials": "^8.1.10",
     "@storybook/addon-interactions": "^8.1.10",
@@ -61,6 +54,7 @@
     "@storybook/react-vite": "^8.1.10",
     "@storybook/test": "^8.1.10",
     "@storybook/theming": "^8.1.10",
+    "@tokens-studio/sd-transforms": "1.2.0",
     "@types/node": "^18.16.1",
     "@types/react": "^17.0.27",
     "@types/react-copy-to-clipboard": "^5",
@@ -77,7 +71,11 @@
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-storybook": "^0.8.0",
     "prettier": "^2.8.8",
+    "react": "^17.0.2",
+    "react-copy-to-clipboard": "^5.1.0",
+    "react-dom": "^17.0.2",
     "storybook": "^8.1.10",
+    "style-dictionary": "4.0.1",
     "terser": "^5.17.1",
     "ts-node": "^10.9.1",
     "tsup": "^6.7.0",


### PR DESCRIPTION
## Description 📝

- Moves packages in `dependencies` to `devDependencies` because this packages's output doesn't depend on any packages 📦 
- This should make result in clearer installation for packages that consume this package 🧹 

## Preview 📷 

This is what http://github.com/linode/manager's lockfile looks like. 
![Screenshot 2024-08-27 at 2 38 26 PM](https://github.com/user-attachments/assets/471ab09d-32db-4bf6-afdd-768b2009c343)

This is what it will look like after

![Screenshot 2024-08-27 at 2 42 59 PM](https://github.com/user-attachments/assets/7beaefea-dc7d-487b-adac-272835be4868)

